### PR TITLE
Add base symbol for Zen 4 patch

### DIFF
--- a/patches.plist
+++ b/patches.plist
@@ -561,7 +561,7 @@
 				<key>Arch</key>
 				<string>x86_64</string>
 				<key>Base</key>
-				<string></string>
+				<string>__ZN11IOPCIBridge13probeBusGatedEP14probeBusParams</string>
 				<key>Comment</key>
 				<string>CaseySJ - probeBusGated Disable 10 bit tags - 12.0/13.0</string>
 				<key>Count</key>


### PR DESCRIPTION
Added ‘base’ symbol "__ZN11IOPCIBridge13probeBusGatedEP14probeBusParams" to Zen 4 patch. This reduces chances of a conflict with other parts of IOPCIFamily.