### PR TITLE
Zen 4 PCI Bus Enumeration Patch for Ventura 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,6 @@ Do not ask for support on GitHub.
 
 - [Acidanthera](https://github.com/acidanthera) for OpenCore.
 
-- [CaseySJ](https://github.com/CaseySJ/) for Zen 4 IOPCIFamily patch.
+- [CaseySJ](https://github.com/CaseySJ/) for Zen 4 IOPCIFamily patches.
 
 - Sinetek, Andy Vandijck, spakk, Bronya, Tora Chi Yo, [Shaneee](https://github.com/Shaneee) and many others for sharing their AMD/XNU kernel knowledge

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The choice is yours. Don't try to use them both at the same time.
 
 Both `mtrr_update_action - fix PAT` patches are not required on TRX40 systems. Disabling them will result in GPU performance improvements. Test this configuration on a USB drive first in preparation for the unlikely event that something goes wrong. Proceed at your own risk.
 
+## Information on the Fix PCI bus enumeration patch
+
+On AM5 motherboards with on-board Thunderbolt/USB4 (e.g. Asus ROG Crosshair X670E Hero, Gene, Extreme; Asus ProArt X670E-Creator), macOS Ventura may not enumerate devices on the PCI bus properly when on-board WiFi and on-board Thunderbolt are both enabled. This patch bypasses the problem. This patch is disabled by default.
+
 ## Supported macOS versions
 
 - macOS High Sierra (10.13)

--- a/patches.plist
+++ b/patches.plist
@@ -661,6 +661,36 @@
 				<key>Skip</key>
 				<integer>0</integer>
 			</dict>
+            <dict>
+                <key>Arch</key>
+                <string>x86_64</string>
+                <key>Base</key>
+                <string>__ZN17IOPCIConfigurator18IOPCIIsHotplugPortEP16IOPCIConfigEntry</string>
+                <key>Comment</key>
+                <string>CaseySJ - Fix PCI bus enumeration on AM5 - 13.0</string>
+                <key>Count</key>
+                <integer>1</integer>
+                <key>Enabled</key>
+                <false/>
+                <key>Find</key>
+                <data>hNt1S0GLVzg=</data>
+                <key>Identifier</key>
+                <string>com.apple.iokit.IOPCIFamily</string>
+                <key>Limit</key>
+                <integer>0</integer>
+                <key>Mask</key>
+                <data></data>
+                <key>MaxKernel</key>
+                <string>22.99.99</string>
+                <key>MinKernel</key>
+                <string>22.0.0</string>
+                <key>Replace</key>
+                <data>hNvrS0GLVzg=</data>
+                <key>ReplaceMask</key>
+                <data></data>
+                <key>Skip</key>
+                <integer>0</integer>
+            </dict>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
This pull request adds the Zen 4 PCI bus enumeration patch for Ventura. Asus AM5 motherboards with built-in Thunderbolt and built-in WiFi are affected. Boards from other manufacturers may also be affected. The patch is disabled by default.

Description of Problem and Patch:
https://forum.amd-osx.com/threads/ryzen-7000-testing.3318/page-106#post-27656