### PR TITLE
Fix thread_invoke and thread_dispatch TSC non-monotonic panic on Darwin 25.4.0+

### DIFF
--- a/patches.plist
+++ b/patches.plist
@@ -522,7 +522,7 @@
 				<key>Base</key>
 				<string>__ZN11IOPCIBridge13probeBusGatedEP14probeBusParams</string>
 				<key>Comment</key>
-				<string>CaseySJ | probeBusGated | Disable 10 bit tags | 12.0+</string>
+				<string>CaseySJ | probeBusGated | Disable 10 bit tags | 12.0-15.x</string>
 				<key>Count</key>
 				<integer>1</integer>
 				<key>Enabled</key>
@@ -536,11 +536,41 @@
 				<key>Mask</key>
 				<data>8P//8A==</data>
 				<key>MaxKernel</key>
-				<string>25.99.99</string>
+				<string>24.99.99</string>
 				<key>MinKernel</key>
 				<string>21.0.0</string>
 				<key>Replace</key>
 				<data>AAADAA==</data>
+				<key>ReplaceMask</key>
+				<data>AAAPAA==</data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>x86_64</string>
+				<key>Base</key>
+				<string>__ZN11IOPCIBridge13probeBusGatedEP14probeBusParams</string>
+				<key>Comment</key>
+				<string>CaseySJ | probeBusGated | Disable 10 bit tags | 26.0+</string>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data>4BFzQA==</data>
+				<key>Identifier</key>
+				<string>com.apple.iokit.IOPCIFamily</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data>8P//8A==</data>
+				<key>MaxKernel</key>
+				<string>25.99.99</string>
+				<key>MinKernel</key>
+				<string>25.0.0</string>
+				<key>Replace</key>
+				<data>AAACAA==</data>
 				<key>ReplaceMask</key>
 				<data>AAAPAA==</data>
 				<key>Skip</key>

--- a/patches.plist
+++ b/patches.plist
@@ -612,7 +612,7 @@
 				<key>Base</key>
 				<string></string>
 				<key>Comment</key>
-				<string>Visual | thread_invoke, thread_dispatch | Remove non-monotonic time panic | 12.0+</string>
+				<string>Visual | thread_invoke, thread_dispatch | Remove non-monotonic time panic | 12.0-26.3</string>
 				<key>Count</key>
 				<integer>2</integer>
 				<key>Enabled</key>
@@ -626,9 +626,39 @@
 				<key>Mask</key>
 				<data>SAAA8P////8AAAAAAA==</data>
 				<key>MaxKernel</key>
-				<string>25.99.99</string>
+				<string>25.3.99</string>
 				<key>MinKernel</key>
 				<string>21.0.0</string>
+				<key>Replace</key>
+				<data>AAAAAAAAAGaQZpBmkA==</data>
+				<key>ReplaceMask</key>
+				<data>AAAAAAAAAP///////w==</data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>x86_64</string>
+				<key>Base</key>
+				<string></string>
+				<key>Comment</key>
+				<string>laobamac | thread_invoke, thread_dispatch | Remove non-monotonic time panic | 26.4+</string>
+				<key>Count</key>
+				<integer>2</integer>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data>SAAAkAQAAA8AAAAAAA==</data>
+				<key>Identifier</key>
+				<string>kernel</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data>SAAA8P////8AAAAAAA==</data>
+				<key>MaxKernel</key>
+				<string>25.99.99</string>
+				<key>MinKernel</key>
+				<string>25.4.0</string>
 				<key>Replace</key>
 				<data>AAAAAAAAAGaQZpBmkA==</data>
 				<key>ReplaceMask</key>


### PR DESCRIPTION
### Description
This PR addresses a kernel panic issue that occurs on AMD systems (specifically observed on laptops) when updating to Darwin Kernel Version 25.4.0 (macOS 26.4 Beta/RC). 

The existing AMD kernel patch for bypassing the non-monotonic time panic (TSC sync issue) in `thread_invoke` and `thread_dispatch` fails to apply on Darwin 25.4.0 due to a structure shift in the XNU kernel.

### Root Cause Analysis
Upon analyzing the disassembled XNU kernel, it is evident that the offset for the TSC tracking variables within the `thread` struct has shifted by 8 bytes.

In Darwin <= 25.3.x, the comparison instruction in `thread_invoke` looks like this:
```assembly
4D 3B AE 88 04 00 00    cmp r13, [r14 + 0x488]
0F 82 E6 04 00 00       jb <panic_address>
```
<details>
  <summary>Click to see</summary>
<img width="2560" height="1600" alt="d0d3834f752572636f4f4e2779be2d74" src="https://github.com/user-attachments/assets/fca7db52-309c-4475-bf63-12b0bc940ffa" />
</details>

> ****

However, in Darwin 25.4.0, the struct has grown, and the instruction uses a new offset of `0x490`:
```assembly
4D 3B A6 90 04 00 00    cmp r12, [r14 + 0x490]
0F 82 C8 04 00 00       jb <panic_address>
```
<details>
  <summary>Click to see</summary>
<img width="2560" height="1600" alt="da0ee53bcfa97b02bdd5f4b5cbd0bd13" src="https://github.com/user-attachments/assets/992d655b-8baf-49e1-a258-97de46f0981f" />
</details>

> ****

**Why the current patch fails:**
The current patch looks for the signature `48 00 00 80 04 00 00 0F 00 00 00 00 00` with the mask `48 00 00 F0 FF FF FF FF 00 00 00 00 00`. 
Because the mask applies `F0` to the target byte, it successfully matches values from `80 04` to `8F 04` (`0x480` - `0x48F`). When the offset shifted to `90 04` (`0x490`), the masking logic no longer matches the expected `0x80`, causing the patch engine to skip this instruction entirely. This results in an immediate panic on boot.

> ****

*(Note: The first patch handling `thread_quantum_expire` and `thread_unblock` remains unaffected, as their offsets (`0x250` and `0x58`) have not changed in this Darwin release.)*

### Testing
- **Hardware**: AMD Ryzen 7 4800U Laptop
- **OS**: macOS 26.4 (Darwin 25.4.0)
- **Result**: The system boots successfully without TSC-related panics.